### PR TITLE
Change the default rounding strategy to `PHP_ROUND_HALF_UP`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.6 - 2017-05-03
+
+* Set a more sane default rounding strategy: `PHP_ROUND_HALF_UP`
+
 ## 1.0.5 - 2017-04-21
 
 * Add `roundFormat()` function which first rounds, then formats the amount, as the regular `format()` function

--- a/src/Money.php
+++ b/src/Money.php
@@ -288,7 +288,7 @@ class Money
      *
      * @return string
      */
-    public function roundFormat($precision = 2, $decPoint = '.', $thousandsSep = '', $mode = PHP_ROUND_HALF_EVEN)
+    public function roundFormat($precision = 2, $decPoint = '.', $thousandsSep = '', $mode = PHP_ROUND_HALF_UP)
     {
         return $this->round($precision, $mode)->format($precision, $decPoint, $thousandsSep);
     }
@@ -387,7 +387,7 @@ class Money
      *
      * @return Money
      */
-    public function round($precision, $mode = PHP_ROUND_HALF_EVEN)
+    public function round($precision, $mode = PHP_ROUND_HALF_UP)
     {
         $amount = Utils::round($this->amount, $precision, $mode);
         return new self($amount, $this->currency);


### PR DESCRIPTION
Currently the default rounding strategy is `PHP_ROUND_HALF_EVEN` which rounds 17.65 to 17.6 and 17.75 to 17.8

This is not compatible with data received from SARS and other SA financial institutions as they use the more traditional `PHP_ROUND_HALF_UP` which rounds 17.65 to 17.7 and 17.75 to 17.8.

This change allows accounts to recon against these documents